### PR TITLE
vitis: match the axipcie driver yaml to the design's PCIe IP (#41)

### DIFF
--- a/Vitis/py/build-vitis.py
+++ b/Vitis/py/build-vitis.py
@@ -182,6 +182,62 @@ def setup_embeddedsw(repo_root, workspace):
 
     return local_esw
 
+# The system device tree names the AXI PCIe root-port flag differently
+# depending on which bridge core the design instantiates:
+#
+#   axi_pcie  (Gen2) -> xlnx,port-type     = <0x1>  (added by the SDT generator
+#                                                    from CONFIG.INCLUDE_RC)
+#   axi_pcie3 (Gen3) -> xlnx,dev-port-type = <0x2>  (the core's DEV_PORT_TYPE
+#                                                    parameter, PCIe port type)
+#
+# Both cores are served by the same axipcie driver, whose axipcie.yaml can name
+# only one of the two in its "required" list -- and the field it does not name
+# is simply absent from the node, so the BSP generator writes 0 into the
+# IncludeRootComplex field of the config table. The application then aborts with
+# "Failed to initialize...AXI PCIE is configured as endpoint" even though the
+# core really is a root port. Point the yaml at the property this design's core
+# actually publishes.
+PCIE_PORT_TYPE_PROPS = [
+    ("xilinx.com:ip:axi_pcie:",  "xlnx,port-type"),
+    ("xilinx.com:ip:axi_pcie3:", "xlnx,dev-port-type"),
+]
+
+def pcie_port_type_prop(xsa_path, bd_name):
+    """SDT property carrying the root-port flag for this design's PCIe bridge.
+    Returns None for designs with no AXI PCIe bridge (xdma/qdma designs use the
+    xdmapcie driver, whose yaml is not patched)."""
+    if not zipfile.is_zipfile(xsa_path):
+        return None
+    vlnvs = []
+    with zipfile.ZipFile(xsa_path, "r") as z:
+        for name in z.namelist():
+            if name.lower() == bd_name + ".hwh":
+                try:
+                    vlnvs += [v for _, v in _find_modules(z.read(name))]
+                except KeyError:
+                    pass
+    for vlnv_prefix, prop in PCIE_PORT_TYPE_PROPS:
+        if any(v.startswith(vlnv_prefix) for v in vlnvs):
+            return prop
+    return None
+
+def set_axipcie_port_type(local_esw, prop):
+    """Rewrite the patched axipcie.yaml's port-type entry to `prop`."""
+    pattern = os.path.join(local_esw, "XilinxProcessorIPLib", "drivers",
+                           "axipcie_v*", "data", "axipcie.yaml")
+    for yaml_path in glob.glob(pattern):
+        with open(yaml_path, "r", encoding="utf-8") as f:
+            text = f.read()
+        new_text, n = re.subn(r"(?m)^([ \t]*-[ \t]*)xlnx,(?:dev-)?port-type[ \t]*$",
+                              r"\g<1>" + prop, text)
+        if not n:
+            info(f"  WARNING: no port-type entry found in {yaml_path}")
+            continue
+        if new_text != text:
+            with open(yaml_path, "w", encoding="utf-8") as f:
+                f.write(new_text)
+        info(f"  axipcie.yaml: root-port property set to {prop}")
+
 def sync_cmake_sources(app_src):
     """Ensure CMakeLists.txt includes all .c files present in app_src.
     Template-based apps generate CMakeLists.txt at creation time, so any
@@ -507,6 +563,11 @@ def main():
         repo_root = os.path.normpath(os.path.join(cwd, ".."))
         local_esw = setup_embeddedsw(repo_root, workspace)
         if local_esw:
+            # Align the patched axipcie.yaml with the PCIe core in this design
+            # (see PCIE_PORT_TYPE_PROPS)
+            port_type_prop = pcie_port_type_prop(xsa_path, bd_name)
+            if port_type_prop:
+                set_axipcie_port_type(local_esw, port_type_prop)
             client.set_embedded_sw_repo(level='LOCAL', path=local_esw)
             info(f"Registered local embeddedsw repo: {local_esw}")
 

--- a/docs/source/revision_history.md
+++ b/docs/source/revision_history.md
@@ -15,6 +15,11 @@
 * Vendored modified `axipcie_v3_4` and `xdmapcie_v3_1` drivers under
   `EmbeddedSw/` to fix SDT compatible-string mapping and Versal QDMA
   address-swap behaviour (see [stand_alone](stand_alone) for details)
+* Fixed the baremetal application aborting with "AXI PCIe is configured as
+  endpoint" on the AXI PCIe Gen2 designs (kc705, vc707, zc706, PicoZed):
+  the Gen2 IP publishes the root-port flag as `xlnx,port-type` while the
+  Gen3 IP publishes it as `xlnx,dev-port-type`, so the axipcie driver YAML
+  is now matched to the PCIe IP in the design (issue #41)
 * Verified the previously documented "Slave Illegal Burst" Vivado 2024.1
   issue no longer reproduces with the current 2025.2 Versal designs;
   removed the AR000036860 tactical-patch workaround note

--- a/docs/source/stand_alone.md
+++ b/docs/source/stand_alone.md
@@ -212,11 +212,24 @@ fails to associate the IP with the axipcie driver, and the BSP is built without 
 Our modified version of `axipcie.yaml` adds `xlnx,axi-pcie3-3.0` as a compatible string so that the
 driver is correctly included in the BSP for designs that use the AXI PCIe Gen3 IP.
 
-Additionally, the YAML references `xlnx,port-type` for the root complex detection field, but the device
-tree uses `xlnx,dev-port-type`. Our patch corrects this so that the `IncludeRootComplex` field in the
-config table is populated correctly. However, the device tree value for root port designs is `2` (PCI
-Express Root Port), while the driver expects `1` (`XAXIPCIE_IS_RC`). The example application normalizes
-any non-zero value to `1` after initialization to satisfy the driver's internal assertions.
+Additionally, the YAML's `required` list names the device tree property that populates the config table's
+`IncludeRootComplex` field — the flag the example application checks to confirm the IP is a root port. The
+two IPs publish that flag under *different* property names, and the YAML can only name one of them:
+
+| PCIe IP | designs | device tree property | value for a root port |
+|---------|---------|----------------------|-----------------------|
+| `axi_pcie` (Gen2) | kc705, vc707, zc706, PicoZed | `xlnx,port-type` | `1` |
+| `axi_pcie3` (Gen3) | kcu105, vc709 | `xlnx,dev-port-type` | `2` |
+
+Whichever property the YAML names, the other IP's node does not have it, the BSP generator writes `0` into
+`IncludeRootComplex`, and the application aborts with *"Failed to initialize...AXI PCIE is configured as
+endpoint"* even though the IP really is a root port. The Vitis build script (`Vitis/py/build-vitis.py`)
+therefore inspects the XSA and sets the YAML's `required` entry to the property that this design's PCIe IP
+actually publishes, before the platform is built.
+
+Note that for the Gen3 IP the value is `2` (PCI Express Root Port), while the driver expects `1`
+(`XAXIPCIE_IS_RC`). The example application normalizes any non-zero value to `1` after initialization to
+satisfy the driver's internal assertions.
 
 ### xdmapcie driver
 


### PR DESCRIPTION
Fixes #41.

The baremetal application aborts with *"Failed to initialize...AXI PCIE is configured as endpoint"* on every AXI PCIe **Gen2** target (`kc705_hpc/lpc`, `vc707_hpc1/hpc2`, `zc706_hpc/lpc`, `pz_7015/7030`), because the generated `xaxipcie_g.c` carries `IncludeRootComplex = 0`.

## Cause

The two PCIe bridge IPs publish the root-port flag under different device tree property names:

| PCIe IP | designs | device tree property | root port value |
|---|---|---|---|
| `axi_pcie` (Gen2) | kc705, vc707, zc706, PicoZed | `xlnx,port-type` | `1` |
| `axi_pcie3` (Gen3) | kcu105, vc709 | `xlnx,dev-port-type` | `2` |

Both are served by the axipcie driver, whose `axipcie.yaml` can name only one of the two in its `required:` list — and the BSP generator writes `0` for any required property that is absent from the node. Since df0b98b the patched yaml named `xlnx,dev-port-type`, which fixed the Gen3 designs and regressed the Gen2 ones.

## Fix

`Vitis/py/build-vitis.py` reads the PCIe IP's VLNV from the XSA and points the workspace copy of the yaml at the property that IP actually publishes. Byte-identical no-op for the Gen3 designs.

## Verification

Full Vivado + Vitis 2025.2 rebuild of `kc705_hpc` on Linux — `xsa` built with no critical warnings, `standalone` built through to `fpgadrv_boot.bit`, and the generated config table now reads:

```c
        "xlnx,axi-pcie-2.9", /* compatible */
        0x10000000, /* reg */
        0x1, /* xlnx,axibar-num */
        0x1, /* xlnx,include-baroffset-reg */
        0x1 /* xlnx,port-type */
```

Not yet run on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)